### PR TITLE
Fix bug with max run time of queue processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 All notable changes for the CiviRFM extension will be noted here.
 
+## [1.2.1] - 2023-11-06
+
+### Changed
+Fixed a bug in the use of $maxRunTime in the processing of queued
+RFM calculation jobs.
+
+## [1.2.0] - 2023-10-31
+
+### Changed
+Shifted from civicrm_post() to civicrm_postCommit() hook function to
+reduce the risk of deadlocks within a transaction context.
+
 ## [1.1.0] - 2023-07-12
 
 ### Added

--- a/Civi/Api4/Action/ContactRfm/RunQueue.php
+++ b/Civi/Api4/Action/ContactRfm/RunQueue.php
@@ -17,7 +17,7 @@ class RunQueue extends \Civi\Api4\Generic\AbstractAction {
   /**
    * Maximum runtime for queue processing (seconds)
    *
-   * @var int|null
+   * @var int
    */
   protected $maxRunTime = 600;
 
@@ -29,7 +29,7 @@ class RunQueue extends \Civi\Api4\Generic\AbstractAction {
       'errorMode' => CRM_Queue_Runner::ERROR_CONTINUE,
     ]);
 
-    $stopTime = time() + $maxRunTime;
+    $stopTime = time() + $this->maxRunTime;
     $continue = TRUE;
     while (time() < $stopTime && $continue) {
       $output = $runner->runNext();

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
   },
   "support": "https://github.com/australiangreens/civirfm/issues",
   "type": "civicrm-ext",
-  "version": "1.2.0"
+  "version": "1.2.1"
   }
 

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/civirfm/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2023-10-31</releaseDate>
-  <version>1.2.0</version>
+  <releaseDate>2023-11-06</releaseDate>
+  <version>1.2.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.57</ver>


### PR DESCRIPTION
Fixes a bug that meant queue processing never occurred. Tested using the API explorer - custom max run times are now supported, and the default 600 seconds properly utilised too.