### PR TITLE
Refactor: Use CiviModels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All notable changes for the CiviRFM extension will be noted here.
 
+## [2.0.0] - 2024-06-07
+
+### Changed
+The CiviRFM extension now makes use of the [CiviModels](https://github.com/australiangreens/civimodels) extension
+for presentation of data on individual contact records. It is not possible to install this extension by itself.
+
+Future work may look to refactor the codebase to enable standalone use. For now however, installation of
+the other extension is required. See the CiviModels repository for more information.
+
+- use the CiviModel extension for displaying model data to back office users
+- remove page route for RFM tab
+- move CiviRFM extension settings menu item under CiviModels menu item
+
 ## [1.2.1] - 2023-11-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 All notable changes for the CiviRFM extension will be noted here.
 
-## [2.0.0] - 2024-06-07
+## [2.0.0] - 2024-06-17
 
 ### Changed
 The CiviRFM extension now makes use of the [CiviModels](https://github.com/australiangreens/civimodels) extension
-for presentation of data on individual contact records. It is not possible to install this extension by itself.
+for presentation of data on individual contact records. It is no longer possible to install this extension by itself.
 
 Future work may look to refactor the codebase to enable standalone use. For now however, installation of
 the other extension is required. See the CiviModels repository for more information.

--- a/civirfm.php
+++ b/civirfm.php
@@ -170,5 +170,7 @@ function civirfm_civimodels_displayCiviModelData($contact_id, &$data) {
       'template' => 'CRM/Civirfm/Page/ContactRfm.tpl'
     ];
     $data['civirfm'] = $civirfm;
+  } else {
+    $data['civirfm'] = ['date_calculated' => NULL];
   }
 }

--- a/info.xml
+++ b/info.xml
@@ -14,12 +14,15 @@
     <url desc="Support">https://github.com/australiangreens/civirfm/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2023-11-06</releaseDate>
-  <version>1.2.1</version>
+  <releaseDate>2024-06-07</releaseDate>
+  <version>2.0.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.57</ver>
+    <ver>5.70</ver>
   </compatibility>
+  <requires>
+    <ext>civimodels</ext>
+  </requires>
   <comments>This extension adds a simple RFM model to CiviCRM for fundraising purposes</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/info.xml
+++ b/info.xml
@@ -14,7 +14,7 @@
     <url desc="Support">https://github.com/australiangreens/civirfm/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-06-07</releaseDate>
+  <releaseDate>2024-06-17</releaseDate>
   <version>2.0.0</version>
   <develStage>stable</develStage>
   <compatibility>

--- a/templates/CRM/Civirfm/Page/ContactRfm.tpl
+++ b/templates/CRM/Civirfm/Page/ContactRfm.tpl
@@ -1,5 +1,5 @@
 <div class='crm-content-block'>
-  <h4>{ts}RFM fundraising information{/ts}</h4>
+  <h4>{ts}RFM Fundraising{/ts}</h4>
     {if isset($model.date_calculated)}
     {* We have RFM values to display *}
     <table class="report-layout" style="max-width: 500px;">

--- a/templates/CRM/Civirfm/Page/ContactRfm.tpl
+++ b/templates/CRM/Civirfm/Page/ContactRfm.tpl
@@ -1,3 +1,4 @@
+{crmScope extensionKey="civirfm'}
 <div class='crm-content-block'>
   <h4>{ts}RFM Fundraising{/ts}</h4>
     {if isset($model.date_calculated)}
@@ -28,3 +29,4 @@
     <p>No RFM data exists for this contact</p>
   {/if}
 </div>
+{/crmScope}

--- a/templates/CRM/Civirfm/Page/ContactRfm.tpl
+++ b/templates/CRM/Civirfm/Page/ContactRfm.tpl
@@ -1,27 +1,25 @@
-{crmScope extensionKey='civirfm'}
 <div class='crm-content-block'>
-  <h3>{ts}RFM fundraising information{/ts}</h3>
-
-  {if isset($date_calc)}
+  <h4>{ts}RFM fundraising information{/ts}</h4>
+    {if isset($model.date_calculated)}
     {* We have RFM values to display *}
     <table class="report-layout" style="max-width: 500px;">
       <thead>
         <tr>
-          <th colspan="2">The following fundraising data was calculated on {ts 1=$date_calc} %1{/ts}</th>
+          <th colspan="2">The following fundraising data was calculated on {ts 1=$model.date_calculated} %1{/ts}</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>Last gift (recency)</td>
-          <td>{ts 1=$recency} %1 days ago{/ts}</td>
+          <td>{ts 1=$model.recency} %1 days ago{/ts}</td>
         </tr>
         <tr>
           <td>Number of gifts (frequency)</td>
-          <td>{ts 1=$frequency 2=$rfm_time} %1 in last %2 years{/ts}</td>
+          <td>{ts 1=$model.frequency 2=$model.rfm_time} %1 in last %2 years{/ts}</td>
         </tr>
         <tr>
           <td>Average gift value (monetary)</td>
-          <td>{ts 1=$curr_symbol 2=$monetary 3=$rfm_time} %1%2 in last %3 years{/ts}</td>
+          <td>{ts 1=$model.curr_symbol 2=$model.monetary 3=$model.rfm_time} %1%2 in last %3 years{/ts}</td>
         </tr>
       </tbody>
     </table>
@@ -30,4 +28,3 @@
     <p>No RFM data exists for this contact</p>
   {/if}
 </div>
-{/crmScope}

--- a/xml/Menu/civirfm.xml
+++ b/xml/Menu/civirfm.xml
@@ -4,12 +4,6 @@
     <path>civicrm/admin/setting/civirfm</path>
     <page_callback>CRM_Admin_Form_Generic</page_callback>
     <title>Configure CiviRFM</title>
-    <access_arguments>access civirfm</access_arguments>
-  </item>
-  <item>
-    <path>civicrm/contact/view/rfm</path>
-    <page_callback>CRM_Civirfm_Page_ContactRfm</page_callback>
-    <title>ContactRfm</title>
-    <access_arguments>access civirfm</access_arguments>
+    <access_arguments>administer civirfm</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
This PR updates the extension to make use of the [CiviModels](https://github.com/australiangreens/civimodels) extension for the presentation of model data to users.

This is a breaking change:
- the extension can no longer be installed without the CiviModels extension already installed
- the CRM Page route has been removed the extension

There are no functional changes in this PR. The extension calculations, jobs, etc., all remain as is. It's purely the presentation of the data that has changed.

This has been tested locally and in our dev deployment.